### PR TITLE
Add sharding support to the ORM

### DIFF
--- a/classes/belongsto.php
+++ b/classes/belongsto.php
@@ -69,6 +69,10 @@ class BelongsTo extends Relation
 			is_array($condition) or $condition = array($key, '=', $condition);
 			$query->where($condition);
 		}
+
+		// propagate shard value into relation models
+		$query->shard_value($from->get_shard_value());
+
 		return $query->get_one();
 	}
 

--- a/classes/hasmany.php
+++ b/classes/hasmany.php
@@ -76,6 +76,9 @@ class HasMany extends Relation
 			}
 		}
 
+		// propagate shard value into relation models
+		$query->shard_value($from->get_shard_value());
+
 		return $query->get();
 	}
 

--- a/classes/hasone.php
+++ b/classes/hasone.php
@@ -66,6 +66,9 @@ class HasOne extends Relation
 			$query->where($condition);
 		}
 
+		// propagate shard value into relation models
+		$query->shard_value($from->get_shard_value());
+
 		return $query->get_one();
 	}
 

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -144,6 +144,9 @@ class ManyMany extends Relation
 
 		$query->_join($join);
 
+		// propagate shard value into relation models
+		$query->shard_value($from->get_shard_value());
+
 		return $query->get();
 	}
 

--- a/classes/model.php
+++ b/classes/model.php
@@ -135,6 +135,11 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 	protected static $to_array_references = array();
 
 	/**
+	 * @var  string|null shard value for this model
+	 */
+	protected $shard_value;
+
+	/**
 	 * Create a new model instance
 	 */
 	public static function forge($data = array(), $new = true, $view = null, $cache = true)
@@ -1377,7 +1382,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 		$this->observe('before_insert');
 
 		// Set all current values
-		$query = Query::forge(get_called_class(), static::connection(true));
+		$query = Query::forge(get_called_class(), static::connection(true), ['shard_value' => $this->get_shard_value()]);
 		$primary_key = static::primary_key();
 		$properties  = array_keys(static::properties());
 		foreach ($properties as $p)
@@ -1429,7 +1434,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 		$this->observe('before_update');
 
 		// Create the query and limit to primary key(s)
-		$query       = Query::forge(get_called_class(), static::connection(true));
+		$query       = Query::forge(get_called_class(), static::connection(true), ['shard_value' => $this->get_shard_value()]);
 		$primary_key = static::primary_key();
 		$properties  = array_keys(static::properties());
 		//Add the primary keys to the where
@@ -1587,7 +1592,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 	protected function delete_self()
 	{
 		// Create the query and limit to primary key(s)
-		$query = Query::forge(get_called_class(), static::connection(true))->limit(1);
+		$query = Query::forge(get_called_class(), static::connection(true), ['shard_value' => $this->get_shard_value()])->limit(1);
 		$primary_key = static::primary_key();
 		foreach ($primary_key as $pk)
 		{
@@ -1933,6 +1938,27 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 	protected function _sanitize($field, $value)
 	{
 		return \Security::clean($value, null, 'security.output_filter');
+	}
+
+	/**
+	 * Returns the shard value for this model
+	 *
+	 * @return string|null
+	 */
+	public function get_shard_value()
+	{
+		return $this->shard_value;
+	}
+
+	/**
+	 * Sets the shard value for this model
+	 *
+	 * @param string|null $shard_value
+	 */
+	public function set_shard_value($shard_value)
+	{
+		$this->shard_value = $shard_value;
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
A bunch of little changes in here to support database sharding at the ORM layer. Both the model and the query classes have been updated to accept a shard value. There is also logic to ensure that the shard value is propagated to relations, hydrated models, and onto the Fuel DB layer so it can be used to create the connection.
